### PR TITLE
Fixing shrinkwrap & broken postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     },
     "bundledDependencies": ["grunt-contrib-clean", "grunt-contrib-copy", "grunt-grunticon", "grunt-dom-munger", "grunt-svgmin", "grunt-text-replace"],
     "devDependencies": {
-        "grunt": ">=0.4.5 <1.0.0",
+        "grunt": "0.4.5",
         "grunt-cli": "~0.1.13",
         "grunt-contrib-jshint": "~0.11.0",
         "grunt-contrib-nodeunit": "~0.4.1"

--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "engines": {
         "node": ">= 0.10.0"
     },
-    "scripts": {
-        "postinstall" : "npm install ./node_modules/grunt-grunticon/node_modules/grunticon-lib/node_modules/svg-to-png --prefix ./node_modules/grunt-grunticon"
-    },
     "dependencies": {
         "grunt-contrib-clean": "~0.6.0",
         "grunt-contrib-copy": "~0.8.0",

--- a/package.json
+++ b/package.json
@@ -33,12 +33,6 @@
         "grunt-text-replace": "~0.4.0"
     },
     "bundledDependencies": ["grunt-contrib-clean", "grunt-contrib-copy", "grunt-grunticon", "grunt-dom-munger", "grunt-svgmin", "grunt-text-replace"],
-    "devDependencies": {
-        "grunt": "0.4.5",
-        "grunt-cli": "~0.1.13",
-        "grunt-contrib-jshint": "~0.11.0",
-        "grunt-contrib-nodeunit": "~0.4.1"
-    },
     "keywords": [
         "gruntplugin"
     ]

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     },
     "bundledDependencies": ["grunt-contrib-clean", "grunt-contrib-copy", "grunt-grunticon", "grunt-dom-munger", "grunt-svgmin", "grunt-text-replace"],
     "devDependencies": {
-        "grunt": "~0.4.5",
+        "grunt": ">=0.4.5 <1.0.0",
         "grunt-cli": "~0.1.13",
         "grunt-contrib-jshint": "~0.11.0",
         "grunt-contrib-nodeunit": "~0.4.1"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "grunt-contrib-nodeunit": "~0.4.1"
     },
     "peerDependencies": {
-        "grunt": "~0.4.5"
+        "grunt": ">=0.4.0"
     },
 
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dependencies": {
         "grunt-contrib-clean": "~0.6.0",
         "grunt-contrib-copy": "~0.8.0",
-        "grunt-grunticon": "~2.2.0",
+        "grunt-grunticon": "~2.2.1",
         "grunt-dom-munger": "~3.4.0",
         "grunt-svgmin": "~2.0.1",
         "grunt-text-replace": "~0.4.0"

--- a/package.json
+++ b/package.json
@@ -39,10 +39,6 @@
         "grunt-contrib-jshint": "~0.11.0",
         "grunt-contrib-nodeunit": "~0.4.1"
     },
-    "peerDependencies": {
-        "grunt": ">=0.4.0"
-    },
-
     "keywords": [
         "gruntplugin"
     ]

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
         "grunt-svgmin": "~2.0.1",
         "grunt-text-replace": "~0.4.0"
     },
-    "bundledDependencies": ["grunt-contrib-clean", "grunt-contrib-copy", "grunt-grunticon", "grunt-dom-munger", "grunt-svgmin", "grunt-text-replace"],
     "keywords": [
         "gruntplugin"
     ]

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "node": ">= 0.10.0"
     },
     "scripts": {
-        "postinstall" : "npm install ./node_modules/grunt-grunticon/node_modules/svg-to-png --prefix ./node_modules/grunt-grunticon"
+        "postinstall" : "npm install ./node_modules/grunt-grunticon/node_modules/grunticon-lib/node_modules/svg-to-png --prefix ./node_modules/grunt-grunticon"
     },
     "dependencies": {
         "grunt-contrib-clean": "~0.6.0",


### PR DESCRIPTION
Hey @mr-winter had a battle with this last week. I wanted to shrinkwrap my npm packages and couldn't with `~2.2.0` (as their 2.2.0 versions are non production, not sure why npm doesn't just load 2.2.1). Also, `grunt-grunticon` has changed the directory structure so the `postinstall` script doesn't work any more but it seems to work for me without it?

Anyway, thought I'd make this PR just in case it was handy, not necessarily to directly merge back into master.

Chur!
