### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "node": ">= 0.10.0"
     },
     "scripts": {
-        "postinstall" : "npm install ./node_modules/grunt-grunticon/node_modules/svg-to-png --prefix ./node_modules/grunt-grunticon"
+        "postinstall": "npm install ./node_modules/grunt-grunticon/node_modules/svg-to-png --prefix ./node_modules/grunt-grunticon"
     },
     "dependencies": {
         "grunt-contrib-clean": "~0.6.0",
@@ -35,7 +35,14 @@
         "grunt-svgmin": "~2.0.1",
         "grunt-text-replace": "~0.4.0"
     },
-    "bundledDependencies": ["grunt-contrib-clean", "grunt-contrib-copy", "grunt-grunticon", "grunt-dom-munger", "grunt-svgmin", "grunt-text-replace"],
+    "bundledDependencies": [
+        "grunt-contrib-clean",
+        "grunt-contrib-copy",
+        "grunt-grunticon",
+        "grunt-dom-munger",
+        "grunt-svgmin",
+        "grunt-text-replace"
+    ],
     "devDependencies": {
         "grunt": "~0.4.5",
         "grunt-cli": "~0.1.13",
@@ -43,9 +50,8 @@
         "grunt-contrib-nodeunit": "~0.4.1"
     },
     "peerDependencies": {
-        "grunt": "~0.4.5"
+        "grunt": ">=0.4.0"
     },
-
     "keywords": [
         "gruntplugin"
     ]


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
